### PR TITLE
nni 를 이용한 auto ml 추가

### DIFF
--- a/baseline/nni/config.yml
+++ b/baseline/nni/config.yml
@@ -1,0 +1,10 @@
+searchSpaceFile: search_space.json
+trialCommand: python3 ../train.py  # NOTE: change "python3" to "python" if you are using Windows
+trialGpuNumber: 0
+trialConcurrency: 1
+tuner:
+  name: TPE
+  classArgs:
+    optimize_mode: maximize
+trainingService:
+  platform: local

--- a/baseline/nni/search_space.json
+++ b/baseline/nni/search_space.json
@@ -1,0 +1,4 @@
+{
+    "batch_size": {"_type":"choice", "_value": [16, 32, 64, 128]}
+
+}

--- a/baseline/train.py
+++ b/baseline/train.py
@@ -18,6 +18,9 @@ from torch.utils.tensorboard import SummaryWriter
 from dataset import MaskBaseDataset
 from loss import create_criterion
 
+import nni
+from nni.utils import merge_parameter
+from munch import munchify
 
 def seed_everything(seed):
     torch.manual_seed(seed)
@@ -326,10 +329,12 @@ def train(data_dir, model_dir, args):
             logger.add_scalar("Val/loss", val_loss, epoch)
             logger.add_scalar("Val/accuracy", val_acc, epoch)
             logger.add_figure("results", figure, epoch)
+            nni.report_intermediate_result(val_acc)
             print()
             if earlystop.early_stop:
                 print('EARLY STOPPED!')
                 break
+        nni.report_final_result(val_acc)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -361,6 +366,9 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     print(args)
+
+    tuner_params=nni.get_next_parameter()
+    args=munch.munchify(merge_parameter(args,tuner_params))
 
     data_dir = args.data_dir
     model_dir = args.model_dir


### PR DESCRIPTION
오피스 아워 강의를 보고 auto ml 구현하여 추가 하였습니다.
https://github.com/microsoft/nni

터미널에서 baseline 폴더 기준으로
nnictl create --config nni/config.yml 과 같은 방법으로 실행 할 수 있고

확인 해볼 param은 search_space.json에 추가하시면 됩니다.

(현재 파일에는 batch_size를 16 32 64 128 로 바꾸어 실행하는 방식)

만약 다른 모델이나 한 param을 고정하고 다른 param을 확인 해보려면

config.yml 파일에서 trialCommand를 터미널에 원래 학습시 넣던 코드 처럼 

train.py --resize 128 96  와 같은 식으로 넣으시면 될 거라고 생각합니다.

너무 많은 param들을 한번에 확인하려면 시간이 아주 많이 걸릴 터이니 

강의에서도 한 두 가지 param만 한번에 확인 하는 게 좋다고 합니다.